### PR TITLE
Implement try_next_line

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -71,11 +71,14 @@ impl<R: Read> Scanner<R> {
     }
 
     pub fn next_line(&mut self) -> String {
+        self.try_next_line().expect("next_line failed.")
+    }
+
+    pub fn try_next_line(&mut self) -> Option<String> {
         assert!(self.tokens.is_empty(), "You have unprocessed token(s)");
         self.lines
             .next()
             .and_then(|e| e.ok())
-            .expect("next_line failed.")
     }
 
     pub fn at_line_start(&mut self) -> bool {


### PR DESCRIPTION
Implemented try_next_line, and refactored the existing next_line function to use it.

This will allow you to safely perform fast reads when the line count is not known ahead-of-time.

Example usage:
```rust
while let Some(line) = sc.try_next_line() {
    // do something
}
```